### PR TITLE
Removed "IF NOT EXISTS" checks, because MySQL does not support them

### DIFF
--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -1,7 +1,7 @@
-CREATE UNIQUE INDEX IF NOT EXISTS `login` ON `ghtorrent`.`users` (`login` ASC)  COMMENT '';
-CREATE UNIQUE INDEX  IF NOT EXISTS  `sha` ON `ghtorrent`.`commits` (`sha` ASC)  COMMENT '';
-CREATE UNIQUE INDEX  IF NOT EXISTS  `comment_id` ON `ghtorrent`.`commit_comments` (`comment_id` ASC)  COMMENT '';
+CREATE UNIQUE INDEX `login` ON `ghtorrent`.`users` (`login` ASC)  COMMENT '';
+CREATE UNIQUE INDEX `sha` ON `ghtorrent`.`commits` (`sha` ASC)  COMMENT '';
+CREATE UNIQUE INDEX `comment_id` ON `ghtorrent`.`commit_comments` (`comment_id` ASC)  COMMENT '';
 CREATE INDEX `follower_id` ON `ghtorrent`.`followers` (`follower_id` ASC) COMMENT '';
-CREATE UNIQUE INDEX  IF NOT EXISTS  `pullreq_id` ON `ghtorrent`.`pull_requests` (`pullreq_id` ASC, `base_repo_id` ASC)  COMMENT '';
-CREATE INDEX  IF NOT EXISTS  `name` ON `ghtorrent`.`projects` (`name` ASC)  COMMENT '';
+CREATE UNIQUE INDEX `pullreq_id` ON `ghtorrent`.`pull_requests` (`pullreq_id` ASC, `base_repo_id` ASC)  COMMENT '';
+CREATE INDEX `name` ON `ghtorrent`.`projects` (`name` ASC)  COMMENT '';
 CREATE INDEX `commit_id` ON `ghtorrent`.`project_commits` (`commit_id` ASC)  COMMENT '';


### PR DESCRIPTION
Tested with MySQL 5.5.46-0ubuntu0.14.04.2 (Ubuntu), see also
http://dba.stackexchange.com/questions/24531/mysql-create-index-if-not-exists