### PR TITLE
Added missing columns to schema of table ghtorrent.users

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS `ghtorrent`.`users` (
   `fake` TINYINT(1) NOT NULL DEFAULT '0' COMMENT '',
   `deleted` TINYINT(1) NOT NULL DEFAULT '0' COMMENT '',
   `long` DECIMAL(11,8) COMMENT '',
-  `lat` DECIMAL(11,8) COMMENT '',
+  `lat` DECIMAL(10,8) COMMENT '',
   `country_code` CHAR(3) COMMENT '',
   `state` VARCHAR(255) COMMENT '',
   `city` VARCHAR(255) COMMENT '',

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -22,6 +22,11 @@ CREATE TABLE IF NOT EXISTS `ghtorrent`.`users` (
   `type` VARCHAR(255) NOT NULL DEFAULT 'USR' COMMENT '',
   `fake` TINYINT(1) NOT NULL DEFAULT '0' COMMENT '',
   `deleted` TINYINT(1) NOT NULL DEFAULT '0' COMMENT '',
+  `long` DECIMAL(11,8) COMMENT '',
+  `lat` DECIMAL(11,8) COMMENT '',
+  `country_code` CHAR(3) COMMENT '',
+  `state` VARCHAR(255) COMMENT '',
+  `city` VARCHAR(255) COMMENT '',
   PRIMARY KEY (`id`)  COMMENT '')
 ENGINE = InnoDB
 DEFAULT CHARACTER SET = utf8;


### PR DESCRIPTION
The columns long, lat, country_code, state, and city were present in the csv file, but not in the schema definition of table ghtorrent.users.