### PR TITLE
Check for existence of correct file in ght-restore

### DIFF
--- a/sql/ght-restore-mysql
+++ b/sql/ght-restore-mysql
@@ -81,7 +81,7 @@ for f in $dumpDir/*.csv ; do
 done
 
 # 3. Create indexes
-if [ ! -e $dumpDir/schema.sql ]; then
+if [ ! -e $dumpDir/indexes.sql ]; then
   echo "Cannot find $dumpDir/indexes.sql to create DB indexes"
   exit 1
 fi


### PR DESCRIPTION
Before using `indexes.sql` in the restore script, a check is made for the existence of `schema.sql` instead of `indexes.sql`. Rectify this.