### PR TITLE
Scripts to add personal data to the database

### DIFF
--- a/sql/ght-add-private
+++ b/sql/ght-add-private
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Add personal data to the GHTorrent database
+# See http://ghtorrent.org/pers-data.html for instructions to obtain
+# the personal data
+#
+
+# defaults
+user="ghtorrent"
+passwd=""
+host="localhost"
+db="ghtorrent"
+engine="MyISAM"
+
+usage()
+{
+  cat <<EOF 1>&2
+Usage: $0 [-u dbuser ] [-p dbpasswd ] [-h dbhost] [-d database ] dump_dir
+
+Add private user data from CSV and SQL files in dump_dir
+    -u database user (default: $user)
+    -p database passwd (default: $passwd)
+    -h database host (default: $host)
+    -d database to restore to. Must exist. (default: $db)
+    -e db engine: MyISAM for fast import and querying speed
+                  InnoDB for normal operations (default: $engine)
+
+The dump directory must contain a file named users_private.csv with the users'
+emails and names.  See http://ghtorrent.org/pers-data.html for instructions
+on how to obtain the personal data.
+EOF
+}
+
+if [ -z "$1" ]
+then
+  usage
+  exit 1
+fi
+
+while getopts "u:p:h:d:e:" o
+do
+  case $o in
+  u)  user=$OPTARG ;;
+  p)  passwd=$OPTARG ;;
+  h)  host=$OPTARG ;;
+  d)  db=$OPTARG ;;
+  e)  engine=$OPTARG ;;
+  \?)     echo "Invalid option: -$OPTARG" >&2
+    usage
+    exit 1
+    ;;
+  esac
+done
+
+# Setup MySQL command line
+if [ -z "$passwd" ]; then
+  mysql="mysql -u $user -s -h $host -D $db"
+else
+  mysql="mysql -u $user --password=$passwd -s -h $host -D $db"
+fi
+
+shift $(expr $OPTIND - 1)
+dumpDir="$1"
+
+if [ ! -d "$dumpDir" ]; then
+  echo "Cannot find directory to restore from" 1>&2
+  exit 1
+fi
+
+# Convert to full path
+dumpDir="$(readlink -f $dumpDir)"
+
+sqlFile="$dumpDir/users_private.sql"
+
+if [ ! -r "$sqlFile" ]; then
+  echo "Cannot read $sqlFile to update DB schema" 1>&2
+  exit 1
+fi
+
+dataFile="$dumpDir/users_private.csv"
+
+if [ ! -r "$dataFile" ]; then
+  echo "Cannot read $dataFile to import the data" 1>&2
+  exit 1
+fi
+
+echo "`date` Updating the database"
+sed -e "
+s/\`ghtorrent\`/\`$db\`/
+s/InnoDB/$engine/
+s/USERS_PRIVATE_FILE/$dataFile/
+/^--/d
+" $sqlFile |
+$mysql
+
+#: ft=bash

--- a/sql/users_private.sql
+++ b/sql/users_private.sql
@@ -1,0 +1,69 @@
+DROP TABLE IF EXISTS users_private;
+
+CREATE TABLE users_private (
+  login VARCHAR(255) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  PRIMARY KEY (login))
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = utf8;
+
+SET foreign_key_checks = 0;
+LOAD DATA INFILE 'USERS_PRIVATE_FILE' INTO TABLE users_private
+CHARACTER SET UTF8 FIELDS TERMINATED BY ','
+OPTIONALLY ENCLOSED BY '"'
+LINES TERMINATED BY '\n';
+
+CREATE UNIQUE INDEX login ON users_private (login ASC);
+
+DROP TABLE IF EXISTS users_new;
+
+CREATE TABLE users_new (
+  id INT(11) NOT NULL AUTO_INCREMENT,
+  login VARCHAR(255) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  company VARCHAR(255) NULL DEFAULT NULL,
+  location VARCHAR(255) NULL DEFAULT NULL,
+  email VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  type VARCHAR(255) NOT NULL DEFAULT 'USR',
+  fake TINYINT(1) NOT NULL DEFAULT '0',
+  deleted TINYINT(1) NOT NULL DEFAULT '0',
+  `long` DECIMAL(11,8),
+  lat DECIMAL(10,8),
+  country_code CHAR(3),
+  state VARCHAR(255),
+  city VARCHAR(255),
+  PRIMARY KEY (id) )
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = utf8;
+
+INSERT INTO users_new (
+  SELECT
+    users.id as id,
+    users.login as login,
+    users_private.name as name,
+    users.company as company,
+    users.location as location,
+    users_private.email as email,
+    users.created_at as created_at,
+    users.type as type,
+    users.fake as fake,
+    users.deleted as deleted,
+    users.`long` as `long`,
+    users.lat as lat,
+    users.country_code as country_code,
+    users.state as state,
+    users.city as city
+  FROM users LEFT JOIN users_private ON
+  users.login = users_private.login
+);
+
+CREATE UNIQUE INDEX login ON users_new (login ASC);
+
+RENAME TABLE users TO users_old;
+
+RENAME TABLE users_new TO users;
+
+DROP TABLE users_old;
+DROP TABLE users_private;


### PR DESCRIPTION
Note: The scripts in their current form are untested, because the `long` field is currently missing.
A very similar script was successfully used to perform the operation on the current data set.