### PR TITLE
Implemented ability to add pull request commits to mongo

### DIFF
--- a/config.yaml.tmpl
+++ b/config.yaml.tmpl
@@ -58,6 +58,10 @@ mirror:
   # Default is 'fork_point'
   fork_commits: fork_point
 
+  # Whether or not you would like to store data in the pull_request_commits collection in Mongo.
+  # Default is 'false'
+  store_pull_request_commits: false
+
 mongo:
   host: 127.0.0.1      # Mongo's IP addr
   port: 27017          # Mongo's port

--- a/lib/ghtorrent/adapters/base_adapter.rb
+++ b/lib/ghtorrent/adapters/base_adapter.rb
@@ -5,7 +5,7 @@ module GHTorrent
     ENTITIES = [:users, :commits, :followers, :repos, :events, :org_members,
         :commit_comments, :repo_collaborators, :watchers, :pull_requests,
         :forks, :pull_request_comments, :issue_comments, :issues, :issue_events,
-        :repo_labels, :geo_cache
+        :repo_labels, :geo_cache, :pull_request_commits
     ].sort
 
     # Stores +data+ into +entity+. Returns a unique key for the stored entry.

--- a/lib/ghtorrent/retriever.rb
+++ b/lib/ghtorrent/retriever.rb
@@ -153,6 +153,29 @@ module GHTorrent
       persister.find(:followers, {'login' => user})
     end
 
+    def retrieve_pull_request_commit(pr_obj, repo, sha, user)
+      pull_commit = persister.find(:pull_request_commits, {'sha' => "#{sha}"})
+
+      if pull_commit.empty?
+        commit = retrieve_commit(repo, sha, user)
+
+        unless commit.nil?
+          commit.delete(nil)
+          commit.delete(:_id)
+          commit.delete('_id')
+          commit['pull_request_id'] = pr_obj[:id]
+          persister.store(:pull_request_commits, commit)
+          info "Added commit #{user}/#{repo} -> #{sha} with pull_id #{pr_obj['id']}"
+          commit
+        else
+          return
+        end
+      else
+        debug "Pull request commit #{user}/#{repo} -> #{sha} exists for pull id #{pr_obj['id']}"
+        pull_commit.first
+      end
+    end
+
     # Retrieve a single commit from a repo
     def retrieve_commit(repo, sha, user)
       commit = persister.find(:commits, {'sha' => "#{sha}"})

--- a/lib/ghtorrent/settings.rb
+++ b/lib/ghtorrent/settings.rb
@@ -23,6 +23,7 @@ module GHTorrent
         :mirror_history_pages_back => 'mirror.history_pages_back',
         :uniq_id => 'mirror.uniq_id',
         :user_agent => 'mirror.user_agent',
+        :store_pull_request_commits => 'mirror.store_pull_request_commits',
 
         :github_token => 'mirror.token',
 
@@ -52,6 +53,7 @@ module GHTorrent
         :mirror_persister => 'noop',
         :mirror_history_pages_back => 10,
         :user_agent => 'ghtorrent',
+        :store_pull_request_commits => 'false',
 
         :github_token => '',
 


### PR DESCRIPTION
This should allow users to choose to add data to the pull_request_commits mongo collection. This is set in the config.yaml