### PR TITLE
Roll up of changes for robustness and logging

### DIFF
--- a/config.yaml.tmpl
+++ b/config.yaml.tmpl
@@ -42,8 +42,8 @@ mirror:
   # Use either a user name/password or an API key
   #token: a valid github API key
 
-  # Number of reqs/hour to do with the provided key
-  req_limit: 4990
+  # Number of reqs/hour to leave on the provided key
+  req_limit: 10
 
   # User agent to use for requests. You must use a unique name per client program
   user_agent: ghtorrent

--- a/config.yaml.tmpl
+++ b/config.yaml.tmpl
@@ -62,6 +62,7 @@ mirror:
 mongo:
   host: 127.0.0.1      # Mongo's IP addr
   port: 27017          # Mongo's port
+#  ssl: true           # use ssl
   db: github           # DB name to store commits to
   username: github     # User name to connect to Mongo
   password: github     # Password for mongo

--- a/config.yaml.tmpl
+++ b/config.yaml.tmpl
@@ -55,6 +55,11 @@ mirror:
   # Default is 'fork_point'
   fork_commits: fork_point
 
+  # Commit handling:
+  #  'trim': Trim off the patch diffs.  These are large and not needed in all scenarios
+  # Default is to not set this property and include all of the commits
+  # commit_handling: trim
+
   # Whether or not you would like to store data in the pull_request_commits collection in Mongo.
   # Default is 'false'
   store_pull_request_commits: false

--- a/lib/ghtorrent/adapters/mongo_persister.rb
+++ b/lib/ghtorrent/adapters/mongo_persister.rb
@@ -14,6 +14,7 @@ module GHTorrent
     LOCALCONFIG = {
         :mongo_host => "mongo.host",
         :mongo_port => "mongo.port",
+        :mongo_ssl => "mongo.ssl",
         :mongo_db => "mongo.db",
         :mongo_username => "mongo.username",
         :mongo_passwd => "mongo.password",
@@ -109,6 +110,7 @@ module GHTorrent
       host = config(:mongo_host)
       port = config(:mongo_port)
       db = config(:mongo_db)
+      ssl = config(:mongo_ssl) ? '?ssl=true' : ''
 
       replicas = config(:mongo_replicas)
       replicas = if replicas.nil? then
@@ -118,9 +120,9 @@ module GHTorrent
                  end
 
       constring = if uname.nil?
-                    "mongodb://#{host}:#{port}#{replicas}/#{db}"
+                    "mongodb://#{host}:#{port}#{replicas}/#{db}#{ssl}"
                   else
-                    "mongodb://#{uname}:#{passwd}@#{host}:#{port}#{replicas}/#{db}"
+                    "mongodb://#{uname}:#{passwd}@#{host}:#{port}#{replicas}/#{db}#{ssl}"
                   end
 
       Mongo::Logger.logger.level = Logger::WARN

--- a/lib/ghtorrent/api_client.rb
+++ b/lib/ghtorrent/api_client.rb
@@ -161,6 +161,7 @@ module GHTorrent
           when 400, # Bad request
               403, # Forbidden
               404, # Not found
+              409, # Conflict -- returned on gets of empty repos
               422 then # Unprocessable entity
             warn request_error_msg(url, e)
             return nil

--- a/lib/ghtorrent/api_client.rb
+++ b/lib/ghtorrent/api_client.rb
@@ -181,7 +181,8 @@ module GHTorrent
         raise e
       ensure
         # The exact limit is only enforced upon the first @reset
-        if 5000 - @remaining >= @req_limit
+        # No idea how many requests are available on this key. Sleep if we have run out
+        if @remaining < @req_limit
           to_sleep = @reset - Time.now.to_i + 2
           debug "Request limit reached, sleeping for #{to_sleep} secs"
           t = Thread.new do

--- a/lib/ghtorrent/api_client.rb
+++ b/lib/ghtorrent/api_client.rb
@@ -185,7 +185,7 @@ module GHTorrent
         # No idea how many requests are available on this key. Sleep if we have run out
         if @remaining < @req_limit
           to_sleep = @reset - Time.now.to_i + 2
-          debug "Request limit reached, sleeping for #{to_sleep} secs"
+          warn "Request limit reached, reset in: #{to_sleep} secs"
           t = Thread.new do
             slept = 0
             while true do
@@ -194,7 +194,7 @@ module GHTorrent
               slept += 1
             end
           end
-          sleep(to_sleep)
+          sleep([0, to_sleep].max)
           t.exit
         end
       end

--- a/lib/ghtorrent/command.rb
+++ b/lib/ghtorrent/command.rb
@@ -94,7 +94,7 @@ Standard options:
             :type => String
         opt :token, 'GitHub OAuth token',
             :type => String, :short => 't'
-        opt :req_limit, 'Request limit for provided account (in reqs/hour)',
+        opt :req_limit, 'Number or requests to leave on any provided account (in reqs/hour)',
             :type => Integer, :short => 'l'
         opt :uniq, 'Unique name for this command. Will appear in logs.',
             :type => String, :short => 'u'

--- a/lib/ghtorrent/commands/full_repo_retriever.rb
+++ b/lib/ghtorrent/commands/full_repo_retriever.rb
@@ -86,7 +86,7 @@ module GHTorrent
           # last update was done too recently (less than 10 days), ignore
           if not repo_entry[:updated_at].nil? \
             and repo_entry[:updated_at] > (Time.now - 10 * 24 * 60 * 60) \
-            and not options[:force_given]
+            and not options[:force]
             warn "Last update too recent (#{Time.at(repo_entry[:updated_at])}) for #{owner}/#{repo}"
             return
           end

--- a/lib/ghtorrent/commands/full_repo_retriever.rb
+++ b/lib/ghtorrent/commands/full_repo_retriever.rb
@@ -60,10 +60,12 @@ module GHTorrent
       end
 
       def retrieve_full_repo(owner, repo)
-        user_entry = ght.transaction { ght.ensure_user(owner, false, false) }
+        start_time = Time.now
+        info "Start fetching: #{owner}/#{repo}"
 
+        user_entry = ght.transaction { ght.ensure_user(owner, false, false) }
         if user_entry.nil?
-          warn "Cannot find user #{owner}"
+          warn "Skip: #{owner}/#{repo}. Owner: #{owner} not found"
           return
         end
 
@@ -79,7 +81,7 @@ module GHTorrent
           repo_entry = ght.ensure_repo(owner, repo)
 
           if repo_entry.nil?
-            warn "Cannot find repository #{owner}/#{repo}"
+            warn "Skip: #{owner}/#{repo}. Repo: #{repo} not found"
             return
           end
 
@@ -87,27 +89,31 @@ module GHTorrent
           if not repo_entry[:updated_at].nil? \
             and repo_entry[:updated_at] > (Time.now - 10 * 24 * 60 * 60) \
             and not options[:force]
-            warn "Last update too recent (#{Time.at(repo_entry[:updated_at])}) for #{owner}/#{repo}"
+            warn "Skip: #{owner}/#{repo}, Too new: #{Time.at(repo_entry[:updated_at])}"
             return
           end
 
           ght.db.from(:projects).where(:id => repo_entry[:id]).update(:updated_at => Time.now)
         end
 
+        stage = nil
         unless options[:no_entities_given]
           begin
             if options[:only_stage].nil?
               stages.each do |x|
+                stage_time = Time.now
                 stage = x
                 ght.send(x, user, repo)
+                info "Stage: #{stage} completed, Repo: #{owner}/#{repo}, Time: #{Time.now.to_ms - stage_time.to_ms} ms"
               end
             else
+              stage_time = Time.now
               stage = options[:only_stage]
               ght.send(options[:only_stage], user, repo)
+              info "Stage: #{stage} completed, Repo: #{owner}/#{repo}, Time: #{Time.now.to_ms - stage_time.to_ms} ms"
             end
           rescue StandardError => e
-            warn("Error processing #{stage} for #{owner}/#{repo}: #{$!}")
-            warn("Exception trace #{e.backtrace.join("\n")}")
+            warn("Error in stage: #{stage}, Repo: #{owner}/#{repo}, Message: #{$!}")
           end
         end
 
@@ -121,13 +127,14 @@ module GHTorrent
               next if options[:events_before_given] and event['id'].to_i >= options[:events_before]
 
               send(event['type'], event)
-              puts "Processed event #{event['type']}-#{event['id']}"
+              info "Processed: #{event['type']}, Id: #{event['id']}"
             rescue StandardError => e
-              puts "Could not process event #{event['type']}-#{event['id']}: #{e.message}"
+              warn "Could not process: #{event['type']}, Id: #{event['id']}: #{e.message}"
             end
           end
         end
       end
+      info "Done fetching: #{owner}/#{repo}, Time: #{Time.now.to_ms - start_time.to_ms} ms"
     end
   end
 end

--- a/lib/ghtorrent/commands/full_user_retriever.rb
+++ b/lib/ghtorrent/commands/full_user_retriever.rb
@@ -37,7 +37,7 @@ module GHTorrent
         if on_github.empty?
           if user_entry.nil?
             warn "User #{login} does not exist on GitHub"
-            exit
+            return
           else
             ght.transaction do
               ght.db.from(:users).where(:login => login).update(:users__deleted => true)
@@ -48,7 +48,7 @@ module GHTorrent
         else
           if user_entry.nil?
             warn "Error retrieving user #{login}"
-            exit
+            return
           end
         end
 

--- a/lib/ghtorrent/commands/ght_mirror_events.rb
+++ b/lib/ghtorrent/commands/ght_mirror_events.rb
@@ -43,6 +43,8 @@ are also queued, to ensure no additional information is gone missing.
   def store_count(events)
     stored = Array.new
     new = dupl = 0
+    return new, dupl, stored if events.nil?
+
     events.each do |e|
       if persister.find(:events, {'id' => e['id']}).empty?
         stored << e

--- a/lib/ghtorrent/commands/repo_updater.rb
+++ b/lib/ghtorrent/commands/repo_updater.rb
@@ -100,6 +100,10 @@ module GHTorrent
       def process_project(owner, name)
         in_mongo = persister.find(:repos, {'owner.login' => owner, 'name' => name })
         on_github = api_request(ghurl ("repos/#{owner}/#{name}"))
+        if on_github.nil?
+          warn "Problem retrieving #{owner}/#{name} from GitHub"
+          return
+        end
 
         ght.transaction do
 

--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -193,7 +193,7 @@ module GHTorrent
             :project_id => project[:id],
             :commit_id => commitid
         )
-        info "Added commit_assoc of #{sha} with #{user}/#{repo}"
+        info "Added commit_assoc #{sha} with #{user}/#{repo}"
         db[:project_commits].first(:project_id => project[:id],
                                     :commit_id => commitid)
       else

--- a/lib/ghtorrent/logging.rb
+++ b/lib/ghtorrent/logging.rb
@@ -8,7 +8,7 @@ module GHTorrent
     include GHTorrent::Settings
 
     def error(msg)
-      log(:warn, msg)
+      log(:error, msg)
     end
 
     def warn(msg)

--- a/lib/ghtorrent/logging.rb
+++ b/lib/ghtorrent/logging.rb
@@ -70,6 +70,8 @@ module GHTorrent
       c = caller[2]
       unless @logprefixes.key? c
         file_path = c.split(/:/)[0]
+        # ignore the first two chars to allow this to run on Windows with c:\...
+        file_path = c[2,c.length - 2].split(/:/)[0]
         @logprefixes[c] = File.basename(file_path) + ': '
       end
 

--- a/lib/ghtorrent/retriever.rb
+++ b/lib/ghtorrent/retriever.rb
@@ -188,6 +188,10 @@ module GHTorrent
           return
         end
 
+        # commit patches are big and not always interesting
+        if config(:commit_handling) == "trim"
+          c["files"].each { |file| file.delete("patch") }
+        end
         unq = persister.store(:commits, c)
         info "Added commit #{user}/#{repo} -> #{sha}"
         c

--- a/lib/ghtorrent/settings.rb
+++ b/lib/ghtorrent/settings.rb
@@ -63,7 +63,7 @@ module GHTorrent
         :attach_ip => '0.0.0.0',
 
         :rescue_loops => 'true',
-        :req_limit => 4998,
+        :req_limit => 2,
         :fork_commits => 'fork_point',
 
         :logging_level => 'info',

--- a/lib/ghtorrent/settings.rb
+++ b/lib/ghtorrent/settings.rb
@@ -32,6 +32,7 @@ module GHTorrent
         :rescue_loops => 'mirror.rescue_loops',
         :req_limit => 'mirror.req_limit',
         :fork_commits => 'mirror.fork_commits',
+        :commit_handling => 'mirror.commit_handling',
 
         :logging_level => 'logging.level',
         :logging_uniq => 'logging.uniq',


### PR DESCRIPTION
This replaces #33 based on further development and the comments made there.  there are several sets of changes each grouped into a single commit. The big picture is around robustness (error handling) and logging.  Quick summary
- widespread nil? checking for anything that directly or indirectly calls GitHub API
- add and update logging particularly for full_repo_retriever
  - I did not add this to the influx db log monitor but will, if you're interested, contribute an Application Insights logger that uses these more detailed messages.
  - there were a couple tweaks to existing log messages to make them more parseable
- add an option to trim the patches off commits.  These are 10x larger than any of the other data combined and not all scenarios require them.
- Grab bag including enable large API keys, ssl to Mongo, running on Windows, 403 and 409 handling
