### PR TITLE
Add topics to repo data

### DIFF
--- a/lib/ghtorrent/adapters/base_adapter.rb
+++ b/lib/ghtorrent/adapters/base_adapter.rb
@@ -5,7 +5,7 @@ module GHTorrent
     ENTITIES = [:users, :commits, :followers, :repos, :events, :org_members,
         :commit_comments, :repo_collaborators, :watchers, :pull_requests,
         :forks, :pull_request_comments, :issue_comments, :issues, :issue_events,
-        :repo_labels, :geo_cache, :pull_request_commits
+        :repo_labels, :geo_cache, :pull_request_commits, :topics
     ].sort
 
     # Stores +data+ into +entity+. Returns a unique key for the stored entry.

--- a/lib/ghtorrent/adapters/mongo_persister.rb
+++ b/lib/ghtorrent/adapters/mongo_persister.rb
@@ -40,7 +40,8 @@ module GHTorrent
         :issue_events          => %w(repo owner issue_id id),
         :issue_comments        => %w(repo owner issue_id id),
         :geo_cache             => %w(key),
-        :pull_request_commits  => %w(sha)
+        :pull_request_commits  => %w(sha),
+        :topics                => %w(repo owner)
     }
 
     attr_reader :settings

--- a/lib/ghtorrent/adapters/mongo_persister.rb
+++ b/lib/ghtorrent/adapters/mongo_persister.rb
@@ -126,7 +126,7 @@ module GHTorrent
             end
 
       constring = if uname.nil?
-                    "mongodb://#{host}:#{port}#{replicas}/#{db}#{ssl}"
+                    "mongodb://#{host}:#{port}#{replicas}/#{db}?ssl=#{ssl}"
                   else
                     "mongodb://#{uname}:#{passwd}@#{host}:#{port}#{replicas}/#{db}?ssl=#{ssl}"
                   end

--- a/lib/ghtorrent/adapters/noop_persister.rb
+++ b/lib/ghtorrent/adapters/noop_persister.rb
@@ -18,7 +18,7 @@ module GHTorrent
       []
     end
 
-    def upsert(entity, query = {})
+    def upsert(entity, query = {}, entry = nil)
       super
       #Nothing to see here
       []

--- a/lib/ghtorrent/commands/full_repo_retriever.rb
+++ b/lib/ghtorrent/commands/full_repo_retriever.rb
@@ -129,7 +129,7 @@ module GHTorrent
               send(event['type'], event)
               info "Success processing event. Type: #{event['type']}, ID: #{event['id']}"
             rescue StandardError => e
-              warn "Error processing event. Type: #{data['type']}, ID: #{data['id']}"
+              warn "Error processing event. Type: #{event['type']}, ID: #{event['id']}"
             end
           end
         end

--- a/lib/ghtorrent/commands/full_repo_retriever.rb
+++ b/lib/ghtorrent/commands/full_repo_retriever.rb
@@ -11,7 +11,7 @@ module GHTorrent
 
       def stages
         %w(ensure_commits ensure_forks ensure_pull_requests
-       ensure_issues ensure_watchers ensure_labels ensure_languages)
+       ensure_issues ensure_watchers ensure_labels ensure_languages ensure_topics)
       end
 
       def settings

--- a/lib/ghtorrent/commands/repo_updater.rb
+++ b/lib/ghtorrent/commands/repo_updater.rb
@@ -66,7 +66,6 @@ module GHTorrent
 
         if db.database_type == :postgres
           t = retrieve_topics(user, repo)
-          info "#{t.inspect}"
           retrieved['topics'] = t['names']
           retrieved['topics'] = Sequel.pg_array(r['topics'], :text)
         else

--- a/lib/ghtorrent/commands/repo_updater.rb
+++ b/lib/ghtorrent/commands/repo_updater.rb
@@ -64,14 +64,6 @@ module GHTorrent
           ght.ensure_fork_commits(owner, repo, parent_owner, parent[:name])
         end
 
-        if db.database_type == :postgres
-          t = retrieve_topics(user, repo)
-          retrieved['topics'] = t['names']
-          retrieved['topics'] = Sequel.pg_array(r['topics'], :text)
-        else
-          retrieved['topics'] = nil
-        end
-
         db.from(:projects, :users).\
         where(:projects__owner_id => :users__id).\
         where(:users__login => owner).\
@@ -86,6 +78,7 @@ module GHTorrent
         info("Repo #{owner}/#{repo} updated")
 
         ght.ensure_languages(owner, repo)
+        ght.ensure_topics(owner, repo)
       end
 
       def get_project_mysql(owner, repo)

--- a/lib/ghtorrent/commands/repo_updater.rb
+++ b/lib/ghtorrent/commands/repo_updater.rb
@@ -82,8 +82,7 @@ module GHTorrent
                :projects__created_at  => date(retrieved['created_at']),
                :projects__updated_at  => Time.now,
                :projects__forked_from => unless parent.nil? then parent[:id] end,
-               :projects__forked_commit_id => unless fork_commit.nil? then fork_commit[:id] end,
-               :projects__topics => retrieved['topics'])
+               :projects__forked_commit_id => unless fork_commit.nil? then fork_commit[:id] end)
         info("Repo #{owner}/#{repo} updated")
 
         ght.ensure_languages(owner, repo)

--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -46,12 +46,6 @@ module GHTorrent
         Sequel::Migrator.apply(@db, dir)
       end
 
-      if db.database_type == :postgres
-        @db.extension :pg_array
-      end
-      @db
-    end
-
     def persister
       @persister ||= connect(config(:mirror_persister), @settings)
       @persister
@@ -576,20 +570,13 @@ module GHTorrent
         curuser = ensure_user(r['owner']['login'], false, false)
       end
 
-      if db.database_type == :postgres
-        r['topics'] = Sequel.pg_array(r['topics'], :text)
-      else
-        r['topics'] = nil
-      end
-
       repos.insert(:url => r['url'],
                    :owner_id => curuser[:id],
                    :name => r['name'],
                    :description => unless r['description'].nil? then r['description'][0..254] else nil end,
                    :language => r['language'],
                    :created_at => date(r['created_at']),
-                   :updated_at => Time.at(86400),
-                   :topics => r['topics'])
+                   :updated_at => Time.at(86400))
 
       unless r['parent'].nil?
         parent_owner = r['parent']['owner']['login']
@@ -1797,7 +1784,6 @@ module GHTorrent
       end
 
     end
-
 
     # Run a block in a DB transaction. Exceptions trigger transaction rollback
     # and are rethrown.

--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -604,7 +604,7 @@ module GHTorrent
       ensure_repo_recursive(user, repo) if recursive
       ensure_topics(user, repo)
 
-      epos.first(:owner_id => curuser[:id], :name => repo)
+      repos.first(:owner_id => curuser[:id], :name => repo)
     end
 
     def ensure_repo_recursive(owner, repo)

--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -602,7 +602,10 @@ module GHTorrent
 
       ensure_repo_recursive(user, repo) if recursive
 
-      repos.first(:owner_id => curuser[:id], :name => repo)
+      final_repo = repos.first(:owner_id => curuser[:id], :name => repo)
+      ensure_topics(user, repo, final_repo)
+
+      final_repo
     end
 
     def ensure_repo_recursive(owner, repo)
@@ -1788,8 +1791,8 @@ module GHTorrent
 
     end
 
-    def ensure_topics(owner, repo)
-      project = ensure_repo(owner, repo)
+    def ensure_topics(owner, repo, repo_row=nil)
+      project = repo_row.nil? ? ensure_repo(owner, repo) : repo_row
       t = retrieve_topics(owner, repo)
 
       t['names'].each do |topic|
@@ -1808,7 +1811,9 @@ module GHTorrent
 
       topic_map.each do |persisted_topic|
         # remove any stored topics that are no longer accurate
-        db[:topic_mappings].delete(:project_id => project[:id], :topic_id => persisted_topic[:topic_id]) if ! t['names'].include?(persisted_topic[:topic_name])
+        if ! t['names'].include?(persisted_topic[:topic_name])
+          db[:topic_mappings].delete(:project_id => project[:id], :topic_id => persisted_topic[:topic_id])
+        end
       end
     end
 

--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -558,6 +558,9 @@ module GHTorrent
 
       unless currepo.nil?
         debug "Repo #{user}/#{repo} exists"
+        if currepo[:topics].nil? # since topics is a newer column
+          repos.filter(:owner_id => curuser[:id], :name => r['name']).update(:topics => r['topics'])
+        end
         return currepo
       end
 
@@ -579,7 +582,8 @@ module GHTorrent
                    :description => unless r['description'].nil? then r['description'][0..254] else nil end,
                    :language => r['language'],
                    :created_at => date(r['created_at']),
-                   :updated_at => Time.at(86400))
+                   :updated_at => Time.at(86400),
+                   :topics => r['topics'])
 
       unless r['parent'].nil?
         parent_owner = r['parent']['owner']['login']
@@ -1786,6 +1790,15 @@ module GHTorrent
         issue_lbl
       end
 
+    end
+
+    def ensure_topics(owner, repo)
+      retrieved = retrieve_topics(owner, repo)
+
+      if retrieved.nil?
+        warn "Could not retrieve repo_label #{owner}/#{repo}/topics"
+        return {}
+      end
     end
 
     # Run a block in a DB transaction. Exceptions trigger transaction rollback

--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -558,7 +558,6 @@ module GHTorrent
 
       unless currepo.nil?
         debug "Repo #{user}/#{repo} exists"
-        ensure_topics(user, repo)
         return currepo
       end
 
@@ -602,7 +601,6 @@ module GHTorrent
       info "Added repo #{user}/#{repo}"
 
       ensure_repo_recursive(user, repo) if recursive
-      ensure_topics(user, repo)
 
       repos.first(:owner_id => curuser[:id], :name => repo)
     end

--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -1810,7 +1810,7 @@ module GHTorrent
 
       topic_map.each do |persisted_topic|
         # remove any stored topics that are no longer accurate
-        db[:topic_mappings].delete(:project_id => project[:id], :topic_id => topic_entry[:topic_id]) if ! t['names'].include?(persisted_topic[:topic_name])
+        db[:topic_mappings].delete(:project_id => project[:id], :topic_id => persisted_topic[:topic_id]) if ! t['names'].include?(persisted_topic[:topic_name])
       end
     end
 

--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -1814,7 +1814,7 @@ module GHTorrent
       project_topics.each do |persisted_topic|
         # remove any stored topics that are no longer accurate
         unless topics.include?(persisted_topic[:topic_name])
-          db[:project_topics].delete(:project_id => project[:id], :topic_name => persisted_topic[:topic_name])
+          db[:project_topics](:project_id => project[:id], :topic_name => persisted_topic[:topic_name]).update(:deleted => true)
         end
       end
 

--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -551,7 +551,7 @@ module GHTorrent
 
       repos = db[:projects]
       curuser = ensure_user(user, false, false)
-      info "#{curuser.inspect}"
+
       if curuser.nil?
         warn "Could not find user #{user}"
         return

--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -1801,23 +1801,20 @@ module GHTorrent
       t = retrieve_topics(owner, repo)
 
       t['names'].each do |topic|
-        # store and map each topic
-        topic_entry = db[:topic_categories].first(:topic_name => topic)
+        # store each topic
+        topic_entry = db[:project_topics].first(:project_id => project[:id], :topic_name => topic)
 
         if topic_entry.nil?
-          db[:topic_categories].insert(:topic_name => topic)
-          topic_entry = db[:topic_categories].first(:topic_name => topic)
+          db[:project_topics].insert(:project_id => project[:id], :topic_name => topic)
         end
-
-        db[:topic_mappings].insert(:project_id => project[:id], :topic_id => topic_entry[:topic_id])
       end
 
-      topic_map = db[:topic_categories].join(db[:topic_mappings].where(:project_id => project[:id]), topic_id: :topic_id)
+      project_topics = db[:project_topics].where(:project_id => project[:id])
 
-      topic_map.each do |persisted_topic|
+      project_topics.each do |persisted_topic|
         # remove any stored topics that are no longer accurate
         if ! t['names'].include?(persisted_topic[:topic_name])
-          db[:topic_mappings].delete(:project_id => project[:id], :topic_id => persisted_topic[:topic_id])
+          db[:project_topics].delete(:project_id => project[:id], :topic_name => persisted_topic[:topic_name])
         end
       end
     end

--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -46,6 +46,9 @@ module GHTorrent
         Sequel::Migrator.apply(@db, dir)
       end
 
+      @db
+    end
+
     def persister
       @persister ||= connect(config(:mirror_persister), @settings)
       @persister

--- a/lib/ghtorrent/migrations/029_add_topics.rb
+++ b/lib/ghtorrent/migrations/029_add_topics.rb
@@ -4,25 +4,20 @@ require 'ghtorrent/migrations/mysql_defaults'
 Sequel.migration do
 
   up do
-    puts 'Adding topic_categories'
-    create_table :topic_categories do
-      primary_key :topic_id
-      String :topic_name, :size => 36, :null => false, index: {unique: true}
-    end
-
-    puts 'Adding topic_mappings'
-    create_table :topic_mappings do
-      foreign_key :topic_id, :topic_categories
+    puts 'Adding table project_topics'
+    create_table :project_topics do
       foreign_key :project_id, :projects
-      primary_key [:topic_id, :project_id]
+      String :topic_name, :size => 36
+      DateTime :created_at, :null => false,
+               :default => Sequel::CURRENT_TIMESTAMP
+
+      primary_key [:project_id, :topic_name]
     end
 
   end
 
   down do
-    puts 'Dropping table topic_mappings'
-    drop_table :topic_mappings
-    puts 'Dropping table topic_categories'
-    drop_table :topic_categories
+    puts 'Dropping table project_topics'
+    drop_table :project_topics
   end
 end

--- a/lib/ghtorrent/migrations/029_add_topics.rb
+++ b/lib/ghtorrent/migrations/029_add_topics.rb
@@ -10,6 +10,7 @@ Sequel.migration do
       String :topic_name, :size => 36
       DateTime :created_at, :null => false,
                :default => Sequel::CURRENT_TIMESTAMP
+      TrueClass :deleted :null => false, :default => false
 
       primary_key [:project_id, :topic_name]
     end

--- a/lib/ghtorrent/migrations/029_add_topics.rb
+++ b/lib/ghtorrent/migrations/029_add_topics.rb
@@ -4,18 +4,27 @@ require 'ghtorrent/migrations/mysql_defaults'
 Sequel.migration do
 
   up do
-    puts 'Adding column topics to projects'
+    puts 'Adding topic_categories'
 
-    alter_table(:projects) do
-      add_column :topics, 'text[]', :null => true, :unique => false
+    create_table :topic_categories do
+      primary_key :topic_id,
+      String :topic_name, :size => 24, :null => false
     end
+
+    puts 'Adding topic_mappings'
+    create_table :topic_mappings do
+      foreign_key :topic_id, :topic_categories
+      foreign_key :project_id, :projects
+      primary_key [:topic_id, :project_id]
+    end
+
 
   end
 
   down do
-    puts 'Dropping column topics from projects'
-    alter_table(:projects) do
-      drop_column :topics
-    end
+    puts 'Dropping table topic_categories'
+    drop_table :topic_categories
+    puts 'Dropping table topic_mappings'
+    drop_table :topic_mappings
   end
 end

--- a/lib/ghtorrent/migrations/029_add_topics.rb
+++ b/lib/ghtorrent/migrations/029_add_topics.rb
@@ -8,7 +8,7 @@ Sequel.migration do
 
     create_table :topic_categories do
       primary_key :topic_id
-      String :topic_name, :size => 24, :null => false
+      String :topic_name, :size => 36, :null => false, index: {unique: true}
     end
 
     puts 'Adding topic_mappings'

--- a/lib/ghtorrent/migrations/029_add_topics.rb
+++ b/lib/ghtorrent/migrations/029_add_topics.rb
@@ -1,0 +1,21 @@
+require 'sequel'
+require 'ghtorrent/migrations/mysql_defaults'
+
+Sequel.migration do
+
+  up do
+    puts 'Adding column topics to projects'
+
+    alter_table(:projects) do
+      add_column :topics, :type => "text[]", :null => true, :unique => false
+    end
+
+  end
+
+  down do
+    puts 'Dropping column topics from projects'
+    alter_table(:projects) do
+      drop_column :topics
+    end
+  end
+end

--- a/lib/ghtorrent/migrations/029_add_topics.rb
+++ b/lib/ghtorrent/migrations/029_add_topics.rb
@@ -20,9 +20,9 @@ Sequel.migration do
   end
 
   down do
-    puts 'Dropping table topic_categories'
-    drop_table :topic_categories
     puts 'Dropping table topic_mappings'
     drop_table :topic_mappings
+    puts 'Dropping table topic_categories'
+    drop_table :topic_categories
   end
 end

--- a/lib/ghtorrent/migrations/029_add_topics.rb
+++ b/lib/ghtorrent/migrations/029_add_topics.rb
@@ -7,7 +7,7 @@ Sequel.migration do
     puts 'Adding topic_categories'
 
     create_table :topic_categories do
-      primary_key :topic_id,
+      primary_key :topic_id
       String :topic_name, :size => 24, :null => false
     end
 

--- a/lib/ghtorrent/migrations/029_add_topics.rb
+++ b/lib/ghtorrent/migrations/029_add_topics.rb
@@ -5,7 +5,6 @@ Sequel.migration do
 
   up do
     puts 'Adding topic_categories'
-
     create_table :topic_categories do
       primary_key :topic_id
       String :topic_name, :size => 36, :null => false, index: {unique: true}
@@ -17,7 +16,6 @@ Sequel.migration do
       foreign_key :project_id, :projects
       primary_key [:topic_id, :project_id]
     end
-
 
   end
 

--- a/lib/ghtorrent/migrations/029_add_topics.rb
+++ b/lib/ghtorrent/migrations/029_add_topics.rb
@@ -7,7 +7,7 @@ Sequel.migration do
     puts 'Adding column topics to projects'
 
     alter_table(:projects) do
-      add_column :topics, :type => "text[]", :null => true, :unique => false
+      add_column :topics, 'text[]', :null => true, :unique => false
     end
 
   end

--- a/lib/ghtorrent/retriever.rb
+++ b/lib/ghtorrent/retriever.rb
@@ -231,6 +231,8 @@ module GHTorrent
         t = retrieve_topics(user, repo)
         info "#{t.inspect}"
         r['topics'] = t['names']
+        info "#{r['name']}"
+        info "#{r['owner']['login']}"
 
         if refresh
           persister.upsert(:repos, {'name' => r['name'], 'owner.login' => r['owner']['login']}, r)

--- a/lib/ghtorrent/retriever.rb
+++ b/lib/ghtorrent/retriever.rb
@@ -229,10 +229,7 @@ module GHTorrent
         end
 
         t = retrieve_topics(user, repo)
-        info "#{t.inspect}"
         r['topics'] = t['names']
-        info "#{r['name']}"
-        info "#{r['owner']['login']}"
 
         if refresh
           persister.upsert(:repos, {'name' => r['name'], 'owner.login' => r['owner']['login']}, r)

--- a/lib/ghtorrent/retriever.rb
+++ b/lib/ghtorrent/retriever.rb
@@ -568,21 +568,16 @@ module GHTorrent
       # https://developer.github.com/v3/repos/#list-all-topics-for-a-repository
       stored_topics = persister.find(:topics, {'owner' => owner, 'repo' => repo })
 
-      if stored_topics.empty? or refresh
+      if stored_topics.empty?
         url = ghurl("repos/#{owner}/#{repo}/topics")
         r = api_request(url, media_type = "application/vnd.github.mercy-preview+json")
-
 
         if r.nil? or r.empty?
           return
         end
 
-        if refresh
-          persister.upsert(:topics, {'repo' =>  repo, 'owner' => owner}, r)
-        else
-          persister.store(:topics, r)
-          info "Added topics for #{owner} -> #{repo}"
-        end
+        persister.store(:topics, r)
+        info "Added topics for #{owner} -> #{repo}"
         r
       else
         debug "Topics for #{owner} -> #{repo} exists"

--- a/lib/ghtorrent/retriever.rb
+++ b/lib/ghtorrent/retriever.rb
@@ -578,7 +578,7 @@ module GHTorrent
         end
 
         if refresh
-          persister.upsert(:topics, {'repo' =>  repo, 'owner' => owner, r)
+          persister.upsert(:topics, {'repo' =>  repo, 'owner' => owner}, r)
         else
           persister.store(:topics, r)
           info "Added topics for #{owner} -> #{repo}"

--- a/lib/ghtorrent/retriever.rb
+++ b/lib/ghtorrent/retriever.rb
@@ -228,6 +228,9 @@ module GHTorrent
           return
         end
 
+        t = ensure_topics(user, repo)
+        r['topics'] = t['topics']
+
         if refresh
           persister.upsert(:repos, {'name' => r['name'], 'owner.login' => r['owner']['login']}, r)
         else
@@ -561,6 +564,14 @@ module GHTorrent
     def retrieve_issue_labels(owner, repo, issue_id)
       url = ghurl("repos/#{owner}/#{repo}/issues/#{issue_id}/labels")
       paged_api_request(url)
+    end
+
+    def retrieve_topics(owner, repo)
+      # https://developer.github.com/v3/repos/#list-all-topics-for-a-repository
+      repo_bound_items(user, repo, :topics,
+                      ["repos/#{owner}/#{repo}/topics"],
+                      {'repo' => repo, 'owner' => user},
+                      'topics', media_type = "application/vnd.github.mercy-preview+json")
     end
 
     # Get current Github events

--- a/lib/ghtorrent/retriever.rb
+++ b/lib/ghtorrent/retriever.rb
@@ -228,8 +228,9 @@ module GHTorrent
           return
         end
 
-        t = ensure_topics(user, repo)
-        r['topics'] = t['topics']
+        t = retrieve_topics(user, repo)
+        info "#{t.inspect}"
+        r['topics'] = t['names']
 
         if refresh
           persister.upsert(:repos, {'name' => r['name'], 'owner.login' => r['owner']['login']}, r)
@@ -567,11 +568,10 @@ module GHTorrent
     end
 
     def retrieve_topics(owner, repo)
+      # volatile: currently available with api preview
       # https://developer.github.com/v3/repos/#list-all-topics-for-a-repository
-      repo_bound_items(user, repo, :topics,
-                      ["repos/#{owner}/#{repo}/topics"],
-                      {'repo' => repo, 'owner' => user},
-                      'topics', media_type = "application/vnd.github.mercy-preview+json")
+      url = ghurl("repos/#{owner}/#{repo}/topics")
+      api_request(url, media_type = "application/vnd.github.mercy-preview+json")
     end
 
     # Get current Github events

--- a/lib/ghtorrent/transacted_gh_torrent.rb
+++ b/lib/ghtorrent/transacted_gh_torrent.rb
@@ -104,6 +104,12 @@ class TransactedGHTorrent < GHTorrent::Mirror
     end
   end
 
+  def ensure_topics(owner, repo)
+    check_transaction do
+      super(owner, repo)
+    end
+  end
+
   def check_transaction(&block)
     if db.in_transaction?
       yield block

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 module GHTorrent
 
-  VERSION = '0.12'
+  VERSION = '0.12.1'
 
 end


### PR DESCRIPTION
Add two topics tables to migrations - topic_mappings and topic_categories - to store topics and ensure normalized/queryable/scalable data

Add topics collection to MongoDB

Create retrieve_topics function in retriever, ensure_topics function in ghtorrent.rb

Call ensure_topics in repo_updater (update_mysql) and full_repo_retriever (stages)
--additionally, call ensure_topics during ensure_repo_recursive

Change version to 0.12.1