### PR TITLE
Add project_topics table schema

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -349,6 +349,22 @@ ENGINE = InnoDB
 DEFAULT CHARACTER SET = utf8;
 
 -- -----------------------------------------------------
+-- Table `ghtorrent`.`project_topics`
+-- -----------------------------------------------------
+DROP TABLE IF EXISTS `ghtorrent`.`project_topics` ;
+
+CREATE TABLE IF NOT EXISTS `ghtorrent`.`project_topics` (
+  `project_id` INT(11) NOT NULL COMMENT '',
+  `topic_name` VARCHAR(255) COMMENT '',
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '',
+  `deleted` TINYINT(1) NOT NULL DEFAULT '0' COMMENT '',
+  CONSTRAINT `project_topics_ibfk_1`
+    FOREIGN KEY (`project_id`)
+    REFERENCES `ghtorrent`.`projects` (`id`))
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = utf8;
+
+-- -----------------------------------------------------
 -- Table `ghtorrent`.`pull_request_comments`
 -- -----------------------------------------------------
 DROP TABLE IF EXISTS `ghtorrent`.`pull_request_comments` ;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -358,6 +358,7 @@ CREATE TABLE IF NOT EXISTS `ghtorrent`.`project_topics` (
   `topic_name` VARCHAR(255) COMMENT '',
   `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '',
   `deleted` TINYINT(1) NOT NULL DEFAULT '0' COMMENT '',
+  PRIMARY KEY (`project_id`, `topic_name`)  COMMENT '',
   CONSTRAINT `project_topics_ibfk_1`
     FOREIGN KEY (`project_id`)
     REFERENCES `ghtorrent`.`projects` (`id`))


### PR DESCRIPTION
Looks like the `project_topics` table was added in [this](https://github.com/gousiosg/github-mirror/blob/b058f06bd69ec7aed7a976c737eb8579904720fd/lib/ghtorrent/migrations/029_add_topics.rb) migration, but no schema was added -- this PR adds the corresponding schema to `sql/schema.sql` in the same style as the other schemas. Tested locally (MariaDB 10.2.12 on Ubuntu 16.04) using the latest mysql dump from ghtorrent.org.