### PR TITLE
Fix syntax error in schema

### DIFF
--- a/sql/pg_schema.sql
+++ b/sql/pg_schema.sql
@@ -284,7 +284,7 @@ CREATE TABLE "users" (
   "country_code" character(3),
   "state" character varying(255),
   "city" character varying(255),
-  "location" character text
+  "location" text
 )
 WITHOUT OIDS;
 


### PR DESCRIPTION
This change fixes the `ERROR: SYNTAX ERROR T OR NEAR "text"` when loading the schema into PostgreSQL.