### PR TITLE
removed character, fixed create table error

### DIFF
--- a/sql/pg_schema.sql
+++ b/sql/pg_schema.sql
@@ -284,7 +284,7 @@ CREATE TABLE "users" (
   "country_code" character(3),
   "state" character varying(255),
   "city" character varying(255),
-  "location" character text
+  "location" text
 )
 WITHOUT OIDS;
 


### PR DESCRIPTION
Having error message near 'location' and 'text', table 'users' never get created, and it caused further problems. 